### PR TITLE
Support multiple users running robot tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /report.html
 /.idea/
 /.tox/
+/tools/argument_file.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 [testenv]
 passenv = *
 setenv =
-    ARG_FILE={env:ARG_FILE:/tmp/argument_file.txt}
+    ARG_FILE={env:ARG_FILE:tools/argument_file.txt}
     PYTHONWARNINGS="ignore:Unverified HTTPS request"
     OPENBMC_PASSWORD=0penBmc
     OPENBMC_USERNAME=root
@@ -15,28 +15,28 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}
 
 [testenv:full]
 deps = {[testenv]deps}
 setenv = {[testenv]setenv}
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} .
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} .
 
 [testenv:tests]
 deps = {[testenv]deps}
 setenv = {[testenv]setenv}
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} tests
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} tests
 
 [testenv:custom]
 deps = {[testenv]deps}
 setenv = {[testenv]setenv}
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}
 
 [testenv:barreleye]
 deps     = {[testenv]deps}
@@ -44,7 +44,7 @@ setenv   = {[testenv]setenv}
     OPENBMC_MODEL=./data/Barreleye.py
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}
 
 [testenv:palmetto]
 deps     = {[testenv]deps}
@@ -52,7 +52,7 @@ setenv   = {[testenv]setenv}
     OPENBMC_MODEL=./data/Palmetto.py
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}
 
 [testenv:firestone]
 deps     = {[testenv]deps}
@@ -60,7 +60,7 @@ setenv   = {[testenv]setenv}
     OPENBMC_MODEL=./data/Firestone.py
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}
 
 [testenv:Garrison]
 deps     = {[testenv]deps}
@@ -68,4 +68,4 @@ setenv   = {[testenv]setenv}
     OPENBMC_MODEL=./data/Garrison.py
 commands =
     bash {toxinidir}/tools/generate_argumentfile.sh
-    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE:/tmp/argument_file.txt} {posargs}
+    python -m robot.run --exclude reboot_tests --argumentfile {env:ARG_FILE} {posargs}


### PR DESCRIPTION
You can use Robot with Jenkins.  What I saw was the argument file was explicitly written to /tmp.  The Jenkins user id is a different user then my user id so when Jenkins owned the /tmp/argument_file.txt my user id trying to do things manually got a file permission error... and visa versa.  So I am moving the argument_file.txt to a location based off of the workspace where the test is being executed.  That allows multiple users on the same system to run the suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc-test-automation/36)
<!-- Reviewable:end -->
