### PR TITLE
remove tox version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ packages which will help to invoke tests through tox.
 
 Install the python dependencies for tox
 ```shell
-    $ easy_install tox==2.1.1
+    $ easy_install tox
     $ easy_install pip
 ```
 


### PR DESCRIPTION
Install the latest tox version that supports the latest tox syntax.
Addresses https://github.com/openbmc/openbmc-test-automation/issues/73