### PR TITLE
Redfish switch between http/https

### DIFF
--- a/data/variables.py
+++ b/data/variables.py
@@ -209,16 +209,40 @@ DUMP_URI = SYSTEM_BASE_URI + 'LogServices/Dump/'
 BIOS_ATTR_URI = SYSTEM_BASE_URI + 'Bios'
 BIOS_ATTR_SETTINGS_URI = BIOS_ATTR_URI + '/Settings'
 
-'''
-  QEMU HTTPS variable:
+# Here are variables get from lib/resource.robot
+RESOURCE_VARIABLES = {
+    "HTTP_PORT": BuiltIn().get_variable_value("${HTTP_PORT}"),
+    "HTTPS_PORT": BuiltIn().get_variable_value("${HTTPS_PORT}"),
+    "HTTPS_ENABLED": BuiltIn().get_variable_value("${HTTPS_ENABLED}"),
+    "OPENBMC_HOST": BuiltIn().get_variable_value("${OPENBMC_HOST}")
+}
 
-  By default lib/resource.robot AUTH URI construct is as
-  ${AUTH_URI}   https://${OPENBMC_HOST}${AUTH_SUFFIX}
-  ${AUTH_SUFFIX} is populated here by default EMPTY else
-  the port from the OS environment
 '''
+  HTTPS/HTTP variables:
+  Here can switch variables between http and https with HTTPS_ENABLED
+  By default lib/resource.robot HTTPS_ENABLED is True
+  SCHEME will be https,AUTH_SUFFIX will be HTTPS_PORT
+  If HTTPS_ENABLED set False SCHEME will be http
+  AUTH_SUFFIX will be HTTP_PORT
+'''
+if RESOURCE_VARIABLES.get("HTTPS_ENABLED") == "True":
+    AUTH_SUFFIX = ":" + RESOURCE_VARIABLES.get("HTTPS_PORT")
+    SCHEME = "https"
+else:
+    AUTH_SUFFIX = ":" + RESOURCE_VARIABLES.get("HTTP_PORT")
+    SCHEME = "http"
 
-AUTH_SUFFIX = ":" + BuiltIn().get_variable_value("${HTTPS_PORT}", os.getenv('HTTPS_PORT', '443'))
+'''
+  Redfish host variable:
+  If OPENBMC_HOST is IPV6
+  REDFISH_HOST is OPENBMC_HOST wrapped with brackets
+  If OPENBMC_HOST is IPV4
+  REDFISH_HOST is OPENBMC_HOST
+'''
+if RESOURCE_VARIABLES.get("OPENBMC_HOST").count(":") > 2:
+    REDFISH_HOST = "[" + RESOURCE_VARIABLES.get("OPENBMC_HOST") + "]"
+else:
+    REDFISH_HOST = RESOURCE_VARIABLES.get("OPENBMC_HOST")
 
 # Here contains a list of valid Properties bases on fru_type after a boot.
 INVENTORY_ITEMS = {

--- a/lib/bmc_redfish_resource.robot
+++ b/lib/bmc_redfish_resource.robot
@@ -3,7 +3,7 @@ Documentation   BMC redfish resource keyword.
 
 Resource        resource.robot
 Resource        rest_response_code.robot
-Library         bmc_redfish.py  https://${OPENBMC_HOST}:${HTTPS_PORT}  ${OPENBMC_USERNAME}
+Library         bmc_redfish.py  ${SCHEME}://${REDFISH_HOST}:${PORT}  ${OPENBMC_USERNAME}
 ...             ${OPENBMC_PASSWORD}  WITH NAME  Redfish
 Library         bmc_redfish_utils.py  WITH NAME  redfish_utils
 Library         disable_warning_urllib.py

--- a/lib/redfish_request.py
+++ b/lib/redfish_request.py
@@ -37,12 +37,22 @@ class redfish_request(object):
         Description of argument(s):
         url        Url passed by user e.g. /redfish/v1/Systems/system.
         """
+        https_enabled = \
+            BuiltIn().get_variable_value("${HTTPS_ENABLED}", default="True")
+
+        if https_enabled == "True":
+            port = \
+                BuiltIn().get_variable_value("${HTTPS_PORT}", default="443")
+        else:
+            port = \
+                BuiltIn().get_variable_value("${HTTP_PORT}", default="80")
+
+        scheme = BuiltIn().get_variable_value("${SCHEME}", default="https")
 
         openbmc_host = \
             BuiltIn().get_variable_value("${OPENBMC_HOST}", default="")
-        https_port = BuiltIn().get_variable_value("${HTTPS_PORT}", default="")
-        form_url = \
-            "https://" + str(openbmc_host) + ":" + str(https_port) + str(url)
+
+        form_url = f"{scheme}://{openbmc_host}:{port}{url}"
 
         return form_url
 

--- a/lib/resource.robot
+++ b/lib/resource.robot
@@ -24,8 +24,8 @@ ${OPENBMC_MODEL}  ${EMPTY}
 ${OPENBMC_HOST}   ${EMPTY}
 ${DBUS_PREFIX}    ${EMPTY}
 ${PORT}           ${EMPTY}
-# AUTH_SUFFIX here is derived from variables.py
-${AUTH_URI}       https://${OPENBMC_HOST}${AUTH_SUFFIX}
+# AUTH_SUFFIX & SCHEME here are derived from variables.py
+${AUTH_URI}       ${SCHEME}://${OPENBMC_HOST}${AUTH_SUFFIX}
 ${OPENBMC_USERNAME}    root
 ${OPENBMC_PASSWORD}    0penBmc
 ${REST_USERNAME}       root
@@ -75,11 +75,13 @@ ${PDU_SLOT_NO}      ${EMPTY}
 
 # User define input SSH and HTTPS related parameters
 ${SSH_PORT}         22
+${HTTP_PORT}        80
 ${HTTPS_PORT}       443
 ${IPMI_PORT}        623
 ${HOST_SOL_PORT}    2200
 ${OPENBMC_SERIAL_HOST}      ${EMPTY}
 ${OPENBMC_SERIAL_PORT}      ${EMPTY}
+${HTTPS_ENABLED}    True
 
 # OS related parameters.
 ${OS_HOST}          ${EMPTY}


### PR DESCRIPTION
[Robot Framework] Redfish switch between http/https

TESTED -- verify on roux
-------VERSION-------
 BMC                 : 22.72
 Bios                : "9999999.20220527.020817-0"
 BMC CPLD version    : 1.0.0.0
 MB CPLD version     : 1.1.0.0
---------------------
Add and move some variables in  variables.py,so it can use conditions to switch bewtween http/https

Add some variables in resource.robot to switch http/https

Replace origin redfish url variables in bmc_redfish_resource.robot

Add conditions in redfish_request.py to switch http/https

Google-Bug-Id: 229142660
Signed-off-by: Yoyo Ho <yoyo.cy.ho@fii-na.corp-partner.google.com>
Change-Id: [I450466d4e2a2c151358e4eb0fbec6c723fae1ebe](https://foxconn-bmc-private-review.googlesource.com/q/I450466d4e2a2c151358e4eb0fbec6c723fae1ebe)